### PR TITLE
Made a few enhancements to the iOS app for modernization

### DIFF
--- a/iOS/OCRuntime.xcodeproj/project.pbxproj
+++ b/iOS/OCRuntime.xcodeproj/project.pbxproj
@@ -465,11 +465,11 @@
 		03959DC6176AFC4D002A1FCC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Nicolas Seriot";
 				TargetAttributes = {
 					03959DCD176AFC4D002A1FCC = {
-						DevelopmentTeam = 36C3524M7W;
+						DevelopmentTeam = HK64RUWW3P;
 					};
 					03959DF1176AFC4E002A1FCC = {
 						TestTargetID = 03959DCD176AFC4D002A1FCC;
@@ -638,6 +638,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -691,7 +692,6 @@
 		03959E04176AFC4E002A1FCC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = armv7;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
@@ -702,6 +702,7 @@
 				GCC_PREFIX_HEADER = "OCRuntime/OCRuntime-Prefix.pch";
 				INFOPLIST_FILE = "OCRuntime/OCRuntime-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "ch.seriot.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
@@ -721,6 +722,7 @@
 				GCC_PREFIX_HEADER = "OCRuntime/OCRuntime-Prefix.pch";
 				INFOPLIST_FILE = "OCRuntime/OCRuntime-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "ch.seriot.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
@@ -743,6 +745,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "OCRuntimeTests/OCRuntimeTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "ch.seriot.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -761,6 +764,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OCRuntime/OCRuntime-Prefix.pch";
 				INFOPLIST_FILE = "OCRuntimeTests/OCRuntimeTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "ch.seriot.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/iOS/OCRuntime/Base.lproj/Main.storyboard
+++ b/iOS/OCRuntime/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="8YX-ce-x5E">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="8YX-ce-x5E">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <scenes>
         <!--Tree-->
@@ -19,7 +19,7 @@
                                 <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="H0w-s5-xjI" id="2bH-fl-oVs">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="V0S-Am-9QJ">
@@ -98,7 +98,7 @@
                                 <rect key="frame" x="0.0" y="66" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YKc-kf-0KS" id="H8M-9B-3zV">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zjf-cr-gM1">
@@ -173,7 +173,7 @@
                                 <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CR2-3n-Ng9" id="zHu-ao-ntk">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eWK-y5-7dW">
@@ -313,7 +313,7 @@ We have found this to be a useful development tool. Please note, however, that e
             <objects>
                 <tableViewController storyboardIdentifier="RTBObjectsTVC" useStoryboardIdentifierAsRestorationIdentifier="YES" id="xsq-ac-6ka" customClass="RTBObjectsTVC" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="DLD-Sc-T7u">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="504"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
@@ -321,7 +321,7 @@ We have found this to be a useful development tool. Please note, however, that e
                                 <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MLO-SK-r0a" id="eNg-ml-svd">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -332,9 +332,9 @@ We have found this to be a useful development tool. Please note, however, that e
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="Wh8-ma-Zsv">
-                        <barButtonItem key="leftBarButtonItem" style="plain" id="O0P-b8-9Ro">
+                        <barButtonItem key="leftBarButtonItem" id="O0P-b8-9Ro">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="JCH-oW-mOs">
-                                <rect key="frame" x="-23" y="-15" width="71" height="30"/>
+                                <rect key="frame" x="16" y="7" width="71" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Close">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -476,7 +476,7 @@ We have found this to be a useful development tool. Please note, however, that e
             <objects>
                 <tableViewController storyboardIdentifier="RTBProtocolsTVC" title="Protocols" useStoryboardIdentifierAsRestorationIdentifier="YES" id="56C-oV-MWn" customClass="RTBProtocolsTVC" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="CPo-0x-pbX">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="455"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <searchBar key="tableHeaderView" contentMode="redraw" id="PIb-Qv-MQI">
@@ -496,7 +496,7 @@ We have found this to be a useful development tool. Please note, however, that e
                                 <rect key="frame" x="0.0" y="66" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KcM-iV-xIj" id="QaI-a4-ltx">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Dkt-sK-Krf">
@@ -547,9 +547,4 @@ We have found this to be a useful development tool. Please note, however, that e
         <image name="tree.png" width="30" height="30"/>
         <image name="use.png" width="30" height="30"/>
     </resources>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/iOS/OCRuntime/OCRuntime-Info.plist
+++ b/iOS/OCRuntime/OCRuntime-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>ch.seriot.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Main</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/iOS/OCRuntime/RTBAppDelegate.m
+++ b/iOS/OCRuntime/RTBAppDelegate.m
@@ -219,7 +219,7 @@
     
     [allClassesByImagesPath enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         BOOL isDylib = [[key pathExtension] isEqualToString:@"dylib"];
-        if([key containsString:name] || (isDylib && [[key lastPathComponent] isEqualToString:[name lastPathComponent]])) {
+        if([key rangeOfString:name].location != NSNotFound || (isDylib && [[key lastPathComponent] isEqualToString:[name lastPathComponent]])) {
             classes = obj;
             *stop = YES;
         }

--- a/iOS/OCRuntime/RTBListTVC.m
+++ b/iOS/OCRuntime/RTBListTVC.m
@@ -25,7 +25,7 @@
 
 - (void)setupIndexedClassStubs {
     
-    self.navigationItem.title = [NSString stringWithFormat:@"%@ (%d)", self.titleForNavigationItem, [self.classStubs count]];
+    self.navigationItem.title = [NSString stringWithFormat:@"%@ (%lu)", self.titleForNavigationItem, (unsigned long)[self.classStubs count]];
     
     NSMutableArray *ma = [[NSMutableArray alloc] init];
     

--- a/iOS/OCRuntime/RTBListTVC.m
+++ b/iOS/OCRuntime/RTBListTVC.m
@@ -35,7 +35,7 @@
     
     for(RTBClass *cs in self.classStubs) {
         
-        if(_filterStringLowercase && [[cs.classObjectName lowercaseString] containsString:_filterStringLowercase] == NO) {
+        if(_filterStringLowercase && [[cs.classObjectName lowercaseString] rangeOfString:_filterStringLowercase].location == NSNotFound) {
             continue;
         }
 

--- a/iOS/OCRuntime/RTBObjectsTVC.m
+++ b/iOS/OCRuntime/RTBObjectsTVC.m
@@ -162,7 +162,7 @@
             if (idx <= 1) return; // skip id and SEL
 
             // eg. "(unsigned long)arg1"
-            NSString *s = [NSString stringWithFormat:@"(%@)arg%d", argType, idx-1];
+            NSString *s = [NSString stringWithFormat:@"(%@)arg%lu", argType, idx-1];
             [params addObject:s];
         }];
         
@@ -510,7 +510,7 @@
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"int"].location != NSNotFound) {
                     // int
-                    int obj = [[parameters objectAtIndex:x] integerValue];
+                    NSInteger obj = [[parameters objectAtIndex:x] integerValue];
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"id"].location != NSNotFound) {
                     // id
@@ -568,7 +568,7 @@
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"int"].location != NSNotFound) {
                     // int
-                    int obj = [[parameters objectAtIndex:x] integerValue];
+                    NSInteger obj = [[parameters objectAtIndex:x] integerValue];
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"id"].location != NSNotFound) {
                     // id
@@ -614,7 +614,7 @@
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"int"].location != NSNotFound) {
                     // int
-                    int obj = [[parameters objectAtIndex:x] integerValue];
+                    NSInteger obj = [[parameters objectAtIndex:x] integerValue];
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"id"].location != NSNotFound) {
                     // id
@@ -666,7 +666,7 @@
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"int"].location != NSNotFound) {
                     // int
-                    int obj = [[parameters objectAtIndex:x] integerValue];
+                    NSInteger obj = [[parameters objectAtIndex:x] integerValue];
                     [inv setArgument:&obj atIndex:(x + 2)];
                 } else if ([[removing objectAtIndex:x] rangeOfString:@"id"].location != NSNotFound) {
                     // id
@@ -725,7 +725,7 @@
         if([returnTypeDecoded isEqualToString:@"NSInteger"] || [returnTypeDecoded isEqualToString:@"NSUInteger"] || [returnTypeDecoded hasSuffix:@"int"]) {
             o = [NSString stringWithFormat:@"%d", (int)o];
         } else if([returnTypeDecoded isEqualToString:@"double"] || [returnTypeDecoded isEqualToString:@"float"]) {
-            o = [NSString stringWithFormat:@"%f", o];
+            o = [NSString stringWithFormat:@"%@", o];
         } else if([returnTypeDecoded isEqualToString:@"BOOL"]) {
             o = ([o boolValue]) ? @"YES" : @"NO";
         } else if ([returnTypeDecoded isEqualToString:@"void"]) {

--- a/iOS/OCRuntime/RTBObjectsTVC.m
+++ b/iOS/OCRuntime/RTBObjectsTVC.m
@@ -725,7 +725,7 @@
         if([returnTypeDecoded isEqualToString:@"NSInteger"] || [returnTypeDecoded isEqualToString:@"NSUInteger"] || [returnTypeDecoded hasSuffix:@"int"]) {
             o = [NSString stringWithFormat:@"%d", (int)o];
         } else if([returnTypeDecoded isEqualToString:@"double"] || [returnTypeDecoded isEqualToString:@"float"]) {
-            o = [NSString stringWithFormat:@"%@", o];
+            o = [NSString stringWithFormat:@"%f", [o floatValue]];
         } else if([returnTypeDecoded isEqualToString:@"BOOL"]) {
             o = ([o boolValue]) ? @"YES" : @"NO";
         } else if ([returnTypeDecoded isEqualToString:@"void"]) {

--- a/iOS/OCRuntime/RTBProtocolsTVC.m
+++ b/iOS/OCRuntime/RTBProtocolsTVC.m
@@ -43,7 +43,7 @@
 
 - (void)setupIndexedClassStubs {
 
-    self.navigationItem.title = [NSString stringWithFormat:@"All Protocols (%d)", [self.protocolStubs count]];
+    self.navigationItem.title = [NSString stringWithFormat:@"All Protocols (%lu)", (unsigned long)[self.protocolStubs count]];
 
     NSMutableArray *ma = [[NSMutableArray alloc] init];
     

--- a/iOS/OCRuntime/RTBProtocolsTVC.m
+++ b/iOS/OCRuntime/RTBProtocolsTVC.m
@@ -53,7 +53,7 @@
     
     for(RTBProtocol *p in self.protocolStubs) {
         
-        if(_filterStringLowercase != nil && [[p.protocolName lowercaseString] containsString:_filterStringLowercase] == NO) {
+        if(_filterStringLowercase != nil && [[p.protocolName lowercaseString] rangeOfString:_filterStringLowercase].location == NSNotFound) {
             continue;
         }
         

--- a/iOS/OCRuntimeTests/OCRuntimeTests-Info.plist
+++ b/iOS/OCRuntimeTests/OCRuntimeTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>ch.seriot.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
Hey,

I adopted the Main.storyboard as the launch storyboard to enable full resolution on iPhone 6(s) (Plus) and fixed a few "incorrect format for argument" warnings. 

I wasn't sure how to handle the retain cycles that the compiler is warning about, because weakSelf is rejected with an error about race conditions, and it felt wrong to do something like this:

      __weak GCDWebServerConnection *weakSelf = self;
      GCDWebServerConnection *strongSelf = weakSelf;

Also, there's one #todo warning in `RTBTreeTVC.m` that didn't have enough context to fix. So I left them.