### PR TITLE
fix out of memory crash

### DIFF
--- a/model/RTBTypeDecoder.m
+++ b/model/RTBTypeDecoder.m
@@ -133,6 +133,8 @@ NSString *rtb_functionSignatureNote(BOOL showFunctionSignatureNote) {
     NSMutableArray *ma = [NSMutableArray array];
     
     while(YES) {
+        @autoreleasepool {
+  
         NSDictionary *d = nil;
         
         [typeDecoder skipDigits];
@@ -148,6 +150,8 @@ NSString *rtb_functionSignatureNote(BOOL showFunctionSignatureNote) {
         }
 
         [ma addObject:d[TYPE_LABEL]];
+            
+        }
     }
     
 //    cacheDictionary[encodedTypes] = ma;
@@ -443,23 +447,31 @@ NSString *rtb_functionSignatureNote(BOOL showFunctionSignatureNote) {
     int i;
     
     //parse each char as an (unnamed) type ... we then need to assign names.
-    for (i=1; *ivT != endCh; ++i) {
-        //structInfo = cTypeDeclForEncType(depth, i, YES, inLine, inParam, YES);
-        structInfo = [self cTypeDeclForEncTypeDepth:depth sPart:i inStruct:YES inLine:inLine inParam:inParam spaceAfter:YES];
-        
-        // Naming for nested pieces is a bit of a kludge.
-        // To support arbitrary nesting w/ unique naming (not required to compile)
-        // we'd need an array of sPart[] and increment sPart[depth] and output
-        // all sParts in sequence to generate a unique name (based on location)
-        if (sPart > 1 || *depth > 1) { // PENDING -- make var (and arg, and category and ...) names a parameter
-            partName = [NSString stringWithFormat:@"x_%d_%d_%d", sPart, (*depth)-1, i];
-        } else {
-            partName = [NSString stringWithFormat:@"x%d", i]; // PENDING -- make var names a parameter
+    for (i=1; *ivT != endCh && *ivT != '\0'; ++i) {
+        @autoreleasepool {
+            
+            //structInfo = cTypeDeclForEncType(depth, i, YES, inLine, inParam, YES);
+            structInfo = [self cTypeDeclForEncTypeDepth:depth sPart:i inStruct:YES inLine:inLine inParam:inParam spaceAfter:YES];
+            
+            // Naming for nested pieces is a bit of a kludge.
+            // To support arbitrary nesting w/ unique naming (not required to compile)
+            // we'd need an array of sPart[] and increment sPart[depth] and output
+            // all sParts in sequence to generate a unique name (based on location)
+            
+            if ([structS length] > 1024) {
+                continue;
+            }
+            
+            if (sPart > 1 || *depth > 1) { // PENDING -- make var (and arg, and category and ...) names a parameter
+                partName = [NSString stringWithFormat:@"x_%d_%d_%d", sPart, (*depth)-1, i];
+            } else {
+                partName = [NSString stringWithFormat:@"x%d", i]; // PENDING -- make var names a parameter
+            }
+            [structS appendString:[structInfo objectForKey:TYPE_LABEL]];
+            [structS appendString:partName];
+            [structS appendString:[structInfo objectForKey:MODIFIER_LABEL]];
+            [structS appendString:@"; "];
         }
-        [structS appendString:[structInfo objectForKey:TYPE_LABEL]];
-        [structS appendString:partName];
-        [structS appendString:[structInfo objectForKey:MODIFIER_LABEL]];
-        [structS appendString:@"; "];
     }
     
     return structS;


### PR DESCRIPTION
1. By using  @autoreleasepool to limit the conut of  temp variable
2. The parser may crash while  seeking '}'  which is out of the string's length.  So add “*ivT != '\0'”  to fix it