### PR TITLE
Search within subdirectories for nested frameworks

### DIFF
--- a/iOS/OCRuntime/RTBFrameworksTVC.m
+++ b/iOS/OCRuntime/RTBFrameworksTVC.m
@@ -207,20 +207,29 @@ static const NSUInteger kPrivateFrameworks = 1;
 }
 
 - (NSArray *)frameworksAtPath:(NSString *)path {
-    NSFileManager *fm = [NSFileManager defaultManager];
-    NSError *error = nil;
-    NSArray *c = [fm contentsOfDirectoryAtPath:path error:&error];
-    if(c == nil) NSLog(@"-- %@", error);
+    NSFileManager *fileManager = [NSFileManager defaultManager];
     
-    NSMutableArray *ma = [NSMutableArray array];
-    for(NSString *s in c) {
-        if([[s pathExtension] isEqualToString:@"framework"]) {
-            NSBundle *b = [NSBundle bundleWithPath:[path stringByAppendingPathComponent:s]];
-            if(b) [ma addObject:b];
+    NSDirectoryEnumerator *directoryEnumerator = [fileManager enumeratorAtURL:[NSURL fileURLWithPath:path] includingPropertiesForKeys:@[] options:0 errorHandler:^BOOL(NSURL *url, NSError *error) {
+        NSLog(@"Error for framework at URL %@ -- %@", url, error);
+        return YES;
+    }];
+    
+    NSMutableArray<NSString *> *frameworks = [NSMutableArray array];
+    for( NSURL *fileURL in directoryEnumerator ) {
+        if ( [fileURL.absoluteString.pathExtension isEqualToString:@"framework"] ) {
+            [frameworks addObject:fileURL.relativePath];
         }
     }
     
-    return ma;
+    NSMutableArray *bundles = [NSMutableArray array];
+    for( NSString *frameworkPath in frameworks ) {
+        NSBundle *bundle = [NSBundle bundleWithPath:frameworkPath];
+        if( bundle ) {
+            [bundles addObject:bundle];
+        }
+    }
+    
+    return bundles;
 }
 
 - (NSArray *)loadedBundleFrameworks {


### PR DESCRIPTION
This commit is to make it so that the app also searches within subdirectories for any frameworks that may be nested within the top level framework. Documentation for NSFileManager contentsOfDirectoryAtPath:error: reads 

> This method performs a shallow search of the directory and therefore does not traverse symbolic links or return the contents of any subdirectories.

 Thus, any frameworks that are inside another framework would not be found under the previous implementation.

One example would be the AVFAudio framework, which is located within AVFoundation.framework. Path:

> /System/Library/Frameworks/AVFoundation.framework/Versions/A/Frameworks/AVFAudio.framework

I could not find the runtime headers for this class when I originally found this repo: https://github.com/nst/iOS-Runtime-Headers