### PR TITLE
Fix progress view in iOS 8 or later

### DIFF
--- a/iOS/OCRuntime/RTBFrameworksTVC.h
+++ b/iOS/OCRuntime/RTBFrameworksTVC.h
@@ -20,7 +20,6 @@
 @property (strong, nonatomic) NSArray *filteredPublicFrameworks;
 @property (strong, nonatomic) NSArray *filteredPrivateFrameworks;
 
-@property (strong, nonatomic) UIAlertView *alertView;
 @property (strong, nonatomic) UIProgressView *progressView;
 @property (strong, nonatomic) UISearchController *searchController;
 

--- a/iOS/OCRuntime/RTBFrameworksTVC.m
+++ b/iOS/OCRuntime/RTBFrameworksTVC.m
@@ -128,16 +128,20 @@ static const NSUInteger kPrivateFrameworks = 1;
 }
 
 - (IBAction)loadAllFrameworks:(id)sender {
-    _alertView = [[UIAlertView alloc] init];
-    _alertView.title = @"Loading All Frameworks";
-    _alertView.message = nil;
     
-    _progressView = [[UIProgressView alloc] initWithFrame:CGRectMake(20.0, 60.0, 245.0, 9.0)];
-    _progressView.progress = 0.0;
-    [_alertView addSubview:_progressView];
-    [_alertView show];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Loading All Frameworks" message:nil preferredStyle:UIAlertControllerStyleAlert];
     
     __weak typeof(self) weakSelf = self;
+    
+    [self presentViewController:alertController animated:YES completion:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if(strongSelf == nil) return;
+        CGFloat margin = 8.0;
+        CGFloat progressHeight = 2;
+        strongSelf.progressView = [[UIProgressView alloc] initWithFrame:CGRectMake(margin, alertController.view.frame.size.height - progressHeight, alertController.view.frame.size.width - margin * 2.0 , progressHeight)];
+        strongSelf.progressView.progress = 0.0;
+        [alertController.view addSubview:strongSelf.progressView];
+    }];
     
     NSBlockOperation *op = [NSBlockOperation blockOperationWithBlock:^{
         
@@ -192,7 +196,7 @@ static const NSUInteger kPrivateFrameworks = 1;
             __strong typeof(weakSelf) strongSelf = weakSelf;
             if(strongSelf == nil) return;
             
-            [strongSelf.alertView dismissWithClickedButtonIndex:0 animated:YES];
+            [strongSelf dismissViewControllerAnimated:YES completion:nil];
             
             [strongSelf.allClasses emptyCachesAndReadAllRuntimeClasses];
             


### PR DESCRIPTION
The progress view shown when load all frameworks did not work in iOS 8 or later. Using UIAlertController to replace UIAlertView will fix this issue, but the minimum version will be iOS 8.
### Before:
![simulator screen shot - iphone x - 2017-10-06 at 19 54 43](https://user-images.githubusercontent.com/2053617/31276902-f22591d2-aa63-11e7-958d-e0ab0b21025e.png)
### After:
![simulator screen shot - iphone x - 2017-10-06 at 19 49 04](https://user-images.githubusercontent.com/2053617/31276909-f93a39c8-aa63-11e7-9959-84c4f3e16d04.png)
### Side effect:
The minimum version will be iOS 8.
