### PR TITLE
Fix dark mode syntax coloring

### DIFF
--- a/OSX/AppController.m
+++ b/OSX/AppController.m
@@ -602,6 +602,9 @@
     [_classBrowser setCellClass:[BrowserCell class]];
     
     [_headerTextView setFont:[NSFont userFixedPitchFontOfSize:11.0]]; // TODO -- make size and font a default
+    if (@available(macOS 10.14, *)) {
+        [_headerTextView setUsesAdaptiveColorMappingForDarkAppearance:YES];
+    }
     
     RBBrowserViewType viewType = [[NSUserDefaults standardUserDefaults] integerForKey:@"RTBViewType"];
     [self changeViewTypeTo:viewType];


### PR DESCRIPTION

|Before|After|
|-|-|
|<img width="659" alt="Before" src="https://user-images.githubusercontent.com/72786/224360639-d999f1fb-323b-4f82-bb3e-8279d37f728e.png">|<img width="664" alt="After" src="https://user-images.githubusercontent.com/72786/224360659-6b632347-e368-4623-881d-7fd45ecac8e7.png">|
